### PR TITLE
Block ranges must be half open

### DIFF
--- a/src/main/scala/org/apache/spark/storage/S3ShuffleReader.scala
+++ b/src/main/scala/org/apache/spark/storage/S3ShuffleReader.scala
@@ -155,7 +155,7 @@ class S3ShuffleReader[K, C](
                      .map(_.blockId)
     } else {
       val indices = S3ShuffleHelper.listShuffleIndicesCached(shuffleId).filter(
-        block => block.mapId >= startMapIndex && block.mapId <= endMapIndex)
+        block => block.mapId >= startMapIndex && block.mapId < endMapIndex)
       if (doBatchFetch || dispatcher.forceBatchFetch) {
         indices.map(block => ShuffleBlockBatchId(block.shuffleId, block.mapId, startPartition, endPartition)).toIterator
       } else {


### PR DESCRIPTION
Looking at spark's MapOutputTracker code, it looks like block ranges to be read are half open i.e. `[startMapIndex,endMapIndex)` but this code seems to be inclusive `[startMapIndex,endMapIndex]`
