### PR TITLE
Cleanup Spark 3.1 

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ These are optional configuration values that control how s3-shuffle behaves.
 - `spark.shuffle.s3.forceBatchFetch`: Force batch fetch for Shuffle Blocks (default: `false`)
 - `spark.shuffle.s3.supportsUnbuffer`: Streams can be unbuffered instead of closed (default: `true`,
   if Storage-backend is S3A, `false` otherwise).
+- `spark.shuffle.s3.prefetchBatchSize`: Prefetch batch size (default: `10`).
+- `spark.shuffle.s3.prefetchThreadPoolSize`: Prefetch thread pool size (default: `40`).
 
 ## Testing
 

--- a/src/main/scala/org/apache/spark/shuffle/helper/S3ShuffleDispatcher.scala
+++ b/src/main/scala/org/apache/spark/shuffle/helper/S3ShuffleDispatcher.scala
@@ -34,9 +34,6 @@ class S3ShuffleDispatcher extends Logging {
   val alwaysCreateIndex: Boolean = conf.getBoolean("spark.shuffle.s3.alwaysCreateIndex", defaultValue = false)
   val useBlockManager: Boolean = conf.getBoolean("spark.shuffle.s3.useBlockManager", defaultValue = true)
   val forceBatchFetch: Boolean = conf.getBoolean("spark.shuffle.s3.forceBatchFetch", defaultValue = false)
-  val allowSerializedShuffle: Boolean = conf.getBoolean("spark.shuffle.s3.allowSerializedShuffle", defaultValue = true)
-  val forceBypassMergeSort: Boolean = conf.getBoolean("spark.shuffle.s3.forceBypassMergeSort", defaultValue = false)
-  val sortShuffleCloneRecords: Boolean = conf.getBoolean("spark.shuffle.s3.sort.cloneRecords", defaultValue = false)
 
   val appDir = f"/${startTime}-${appId}/"
   val fs: FileSystem = FileSystem.get(URI.create(rootDir), {
@@ -49,9 +46,6 @@ class S3ShuffleDispatcher extends Logging {
   logInfo(s"- spark.shuffle.s3.alwaysCreateIndex=${alwaysCreateIndex}")
   logInfo(s"- spark.shuffle.s3.useBlockManager=${useBlockManager}")
   logInfo(s"- spark.shuffle.s3.forceBatchFetch=${forceBatchFetch}")
-  logInfo(s"- spark.shuffle.s3.allowSerializedShuffle=${allowSerializedShuffle}")
-  logInfo(s"- spark.shuffle.s3.forceBypassMergeSort=${forceBypassMergeSort}")
-  logInfo(s"- spark.shuffle.s3.sort.cloneRecords=${sortShuffleCloneRecords}")
 
   def removeRoot(): Boolean = {
     Range(0, 10).map(idx => {

--- a/src/main/scala/org/apache/spark/shuffle/helper/S3ShuffleDispatcher.scala
+++ b/src/main/scala/org/apache/spark/shuffle/helper/S3ShuffleDispatcher.scala
@@ -34,6 +34,8 @@ class S3ShuffleDispatcher extends Logging {
   val alwaysCreateIndex: Boolean = conf.getBoolean("spark.shuffle.s3.alwaysCreateIndex", defaultValue = false)
   val useBlockManager: Boolean = conf.getBoolean("spark.shuffle.s3.useBlockManager", defaultValue = true)
   val forceBatchFetch: Boolean = conf.getBoolean("spark.shuffle.s3.forceBatchFetch", defaultValue = false)
+  val prefetchBatchSize: Int = conf.getInt("spark.shuffle.s3.prefetchBatchSize", defaultValue = 10)
+  val prefetchThreadPoolSize: Int = conf.getInt("spark.shuffle.s3.prefetchThreadPoolSize", defaultValue = 20)
 
   val appDir = f"/${startTime}-${appId}/"
   val fs: FileSystem = FileSystem.get(URI.create(rootDir), {
@@ -46,6 +48,8 @@ class S3ShuffleDispatcher extends Logging {
   logInfo(s"- spark.shuffle.s3.alwaysCreateIndex=${alwaysCreateIndex}")
   logInfo(s"- spark.shuffle.s3.useBlockManager=${useBlockManager}")
   logInfo(s"- spark.shuffle.s3.forceBatchFetch=${forceBatchFetch}")
+  logInfo(s"- spark.shuffle.s3.prefetchBlockSize=${prefetchBatchSize}")
+  logInfo(s"- spark.shuffle.s3.prefetchThreadPoolSize=${prefetchThreadPoolSize}")
 
   def removeRoot(): Boolean = {
     Range(0, 10).map(idx => {

--- a/src/main/scala/org/apache/spark/shuffle/sort/S3ShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/sort/S3ShuffleManager.scala
@@ -27,12 +27,9 @@ import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.shuffle._
 import org.apache.spark.shuffle.api.ShuffleExecutorComponents
-import org.apache.spark.shuffle.helper.S3ShuffleHelper.dispatcher
 import org.apache.spark.shuffle.helper.{S3ShuffleDispatcher, S3ShuffleHelper}
 import org.apache.spark.storage.S3ShuffleReader
-import org.apache.spark.util.collection.OpenHashSet
 
-import java.util.concurrent.ConcurrentHashMap
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/src/main/scala/org/apache/spark/storage/S3ShuffleReader.scala
+++ b/src/main/scala/org/apache/spark/storage/S3ShuffleReader.scala
@@ -119,7 +119,7 @@ class S3ShuffleReader[K, C](
       }(S3ShuffleReader.asyncExecutionContext)
     }
 
-    val recordIter = slidingPrefetchIterator(recordIterPromise, 25).flatten
+    val recordIter = slidingPrefetchIterator(recordIterPromise, dispatcher.prefetchBatchSize).flatten
 
     // Update the context task metrics for each record read.
     val metricIter = CompletionIterator[(Any, Any), Iterator[(Any, Any)]](
@@ -204,6 +204,6 @@ class S3ShuffleReader[K, C](
 }
 
 object S3ShuffleReader {
-  private val asyncThreadPool = ThreadUtils.newDaemonCachedThreadPool("s3-shuffle-reader-async-thread-pool", 100)
-  private implicit val asyncExecutionContext = ExecutionContext.fromExecutorService(asyncThreadPool)
+  private lazy val asyncThreadPool = ThreadUtils.newDaemonCachedThreadPool("s3-shuffle-reader-async-thread-pool", S3ShuffleDispatcher.get.prefetchThreadPoolSize)
+  private lazy implicit val asyncExecutionContext = ExecutionContext.fromExecutorService(asyncThreadPool)
 }

--- a/src/test/scala/org/apache/spark/shuffle/S3ShuffleManagerTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/S3ShuffleManagerTest.scala
@@ -252,5 +252,4 @@ class S3ShuffleManagerTest {
     .set("spark.local.dir", "./spark-temp") // Configure the working dir.
     .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.S3ShuffleManager")
     .set("spark.shuffle.sort.io.plugin.class", "org.apache.spark.shuffle.S3ShuffleDataIO")
-    .set("spark.shuffle.s3.forceBypassMergeSort", "false")
 }


### PR DESCRIPTION
- Remove unused configuration variables.
- Make `prefetchBatchSize` and `prefetchThreadPoolSize` configurable.