### PR TITLE
Spark 3.1: Fix TeraSort + TPC-DS Query examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ These are optional configuration values that control how s3-shuffle behaves.
   [IBM COS](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-versioning#versioning-consistency)
   both are strongly consistent and are thus not affected.
 - `spark.shuffle.s3.forceBatchFetch`: Force batch fetch for Shuffle Blocks (default: `false`)
-- `spark.shuffle.s3.supportsUnbuffer`: Streams can be unbuffered instead of closed (default: `true`,
   if Storage-backend is S3A, `false` otherwise).
 - `spark.shuffle.s3.prefetchBatchSize`: Prefetch batch size (default: `25`).
 - `spark.shuffle.s3.prefetchThreadPoolSize`: Prefetch thread pool size (default: `100`).

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ These are optional configuration values that control how s3-shuffle behaves.
 - `spark.shuffle.s3.forceBatchFetch`: Force batch fetch for Shuffle Blocks (default: `false`)
 - `spark.shuffle.s3.supportsUnbuffer`: Streams can be unbuffered instead of closed (default: `true`,
   if Storage-backend is S3A, `false` otherwise).
-- `spark.shuffle.s3.prefetchBatchSize`: Prefetch batch size (default: `10`).
-- `spark.shuffle.s3.prefetchThreadPoolSize`: Prefetch thread pool size (default: `40`).
+- `spark.shuffle.s3.prefetchBatchSize`: Prefetch batch size (default: `25`).
+- `spark.shuffle.s3.prefetchThreadPoolSize`: Prefetch thread pool size (default: `100`).
 
 ## Testing
 
@@ -56,14 +56,14 @@ The tests require the following environment variables to be set:
 - `S3_ENDPOINT_URL`: Endpoint URL of the S3 Service (e.g. `http://10.40.0.29:9000` or
   `https://s3.direct.us-south.cloud-object-storage.appdomain.cloud`).
 - `S3_ENDPOINT_USE_SSL`: Whether the endpoint supports SSL or not.
-- `S3_SHUFFLE_ROOT`: The shuffle root (e.g `s3a://zrlio-tmp/S3ShuffleManagerTests`)
+- `S3_SHUFFLE_ROOT`: The shuffle root (e.g `s3a://zrlio-tmp/`)
 
 ## Usage
 
 Copy one of the following files to your spark path:
 
-- `spark-s3-shuffle_2.12-1.0-SNAPSHOT-jar-with-dependencies.jar` (created by `sbt assembly`)
-- `spark-s3-shuffle_2.12-1.0-SNAPSHOT.jar` (created by `sbt package`)
+- `spark-s3-shuffle_2.12-SPARK_VERSION_SNAPSHOT-jar-with-dependencies.jar` (created by `sbt assembly`)
+- `spark-s3-shuffle_2.12-SPARK_VERSION_SNAPSHOT.jar` (created by `sbt package`)
 
 ### With S3 Plugin
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,52 @@
+# Readme
+
+This folder contains a set of examples for the HDFS connector.
+
+## Prequisites
+
+1. A Apache Spark installation
+2. A Kubernetes Cluster
+3. A S3 Bucket / or a local S3 installation (see `config.sh` for the configuration). 
+4. Configure `s3cmd` with the S3 credentials to enable cleanup.
+
+## Steps
+
+Modify `config_X.X.X.sh` based on your setup.
+
+Run the following commands to build the docker containers:
+
+```bash
+source config_X.X.X.sh
+./terasort/build.sh
+./sql/build.sh
+```
+
+## Running
+
+Use the following environment variables to configure the Spark:
+- `USE_S3_SHUFFLE=1` Enable Shuffle on S3 (default: on)
+- `USE_S3_SHUFFLE=0` Disable Shuffle on S3 (default: on)
+
+### TeraSort
+
+```bash
+export SIZE=1g           # Options: 1g (default), 10g, 100g
+export USE_S3_SHUFFLE=1  # Options: 0, 1 (default)
+./terasort/run.sh
+```
+
+### SQL
+
+Run a single query ([full list](https://github.com/zrlio/sql-benchmarks/blob/master/src/main/scala/com/ibm/crail/benchmarks/tests/tpcds/TPCDSQueries.scala) - omit `.sql`).
+```bash
+export SIZE=1000        # Options: 10, 100, 1000 (default)
+export USE_S3_SHUFFLE=1 # Options: 0, 1 (default)
+./sql/run_single_query.sh q67
+```
+
+Run tpcds:
+```bash
+export SIZE=100         # Options: 10, 100 (default), 1000
+export USE_S3_SHUFFLE=1 # Options: 0, 1 (default) (enable shuffle on S3)
+./sql/run_tpcds.sh
+```

--- a/examples/config_3.1.3.sh
+++ b/examples/config_3.1.3.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023- IBM Inc. All rights reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+
+## Spark installation
+# wget https://archive.apache.org/dist/spark/spark-3.1.3/spark-3.1.3-bin-hadoop3.2.tgz
+export SPARK_HOME="/home/${USER}/software/spark-3.1.3-bin-hadoop3.2"
+
+## Build Configuration for the Spark Docker container
+# Determine dependencies using https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.12/3.1.3
+export SPARK_VERSION=3.1.3
+export S3_SHUFFLE_VERSION=0.7.1-spark3.1
+export HADOOP_VERSION=3.2.0
+export AWS_SDK_VERSION=1.11.375
+
+# Kubernetes Config
+export KUBERNETES_SERVER="https://9.4.244.122:6443" # export CodeEngine: "https://proxy.us-south.codeengine.cloud.ibm.com"
+export KUBERNETES_PULL_SECRETS_NAME="zac-registry"
+export KUBERNETES_NAMESPACE=$(kubectl config view --minify -o jsonpath='{..namespace}')
+export KUBERNETES_SERVICE_ACCOUNT="${KUBERNETES_NAMESPACE}-manager"
+
+# Image configuration
+export DOCKER_REGISTRY="zac32.zurich.ibm.com"
+export DOCKER_IMAGE_PREFIX="${PREFIX:-"${USER}/"}"
+
+# S3 Config
+export S3A_ENDPOINT="http://10.40.0.29:9000"
+export S3A_ACCESS_KEY=${S3A_ACCESS_KEY:-$AWS_ACCESS_KEY_ID}
+export S3A_SECRET_KEY=${S3A_SECRET_KEY:-$AWS_SECRET_ACCESS_KEY}
+export S3A_OUTPUT_BUCKET=${S3A_BUCKET:-"zrlio-tmp"}
+export SHUFFLE_DESTINATION=${SHUFFLE_DESTINATION:-"s3a://zrlio-tmp"}
+
+# Datasets
+## Terasort
+# Contains the following datasets:
+# - 1g
+# - 10g
+# - 100g
+export TERASORT_BUCKET=zrlio-terasort
+
+## TPCDS
+# Contains the following datasets:
+# - sf1000_parquet
+# - sf100_parquet
+# - sf10_parquet
+export TPCDS_BUCKET=zrlio-tpcds

--- a/examples/sql/Dockerfile
+++ b/examples/sql/Dockerfile
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023- IBM Inc. All rights reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+
+ARG SPARK_VERSION
+ARG S3_SHUFFLE_VERSION
+ARG HADOOP_VERSION
+ARG AWS_SDK_VERSION
+
+FROM debian:11.5 as java-prerequisites
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+
+RUN apt-get clean && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        openjdk-11-jdk-headless git maven wget \
+    && apt-get clean
+
+###
+# SQL-Benchmarks
+FROM java-prerequisites as sql-builder
+
+RUN git clone https://github.com/zrlio/sql-benchmarks \
+    && cd sql-benchmarks \
+    && mvn package
+
+# Result /sql-benchmarks/target/sql-benchmarks-1.0.jar
+
+###
+# S3-Shuffle plugin
+FROM sbtscala/scala-sbt:eclipse-temurin-focal-11.0.17_8_1.9.1_2.12.18 as s3-shuffle-builder
+
+ARG SPARK_VERSION
+ENV SPARK_VERSION=${SPARK_VERSION}
+
+COPY . /spark-s3-shuffle
+RUN cd /spark-s3-shuffle \
+    && sbt package \
+    && ls target/scala-2.12/*
+
+# Result /spark-s3-shuffle/target/scala-2.12/spark-s3-shuffle_2.12-${SPARK_VERSION}_SNAPSHOT.jar 
+
+###
+# Spark Container
+FROM docker.io/apache/spark-py:v${SPARK_VERSION}
+
+ARG SPARK_VERSION
+ARG S3_SHUFFLE_VERSION
+ARG HADOOP_VERSION
+ARG AWS_SDK_VERSION
+
+ADD https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/${HADOOP_VERSION}/hadoop-aws-${HADOOP_VERSION}.jar "${SPARK_HOME}/jars/hadoop-aws-${HADOOP_VERSION}.jar"
+ADD https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/${AWS_SDK_VERSION}/aws-java-sdk-bundle-${AWS_SDK_VERSION}.jar "${SPARK_HOME}/jars/aws-java-sdk-bundle-${AWS_SDK_VERSION}.jar"
+
+# S3-Shuffle plugin
+COPY --from=s3-shuffle-builder /spark-s3-shuffle/target/scala-2.12/spark-s3-shuffle_2.12-${SPARK_VERSION}_SNAPSHOT.jar "${SPARK_HOME}/jars/"
+# Release
+# ADD https://github.com/IBM/spark-s3-shuffle/releases/download/v${S3_SHUFFLE_VERSION}/spark-s3-shuffle_2.12-${SPARK_VERSION}_${S3_SHUFFLE_VERSION}.jar "${SPARK_HOME}/jars/spark-s3-shuffle_2.12-${SPARK_VERSION}_${S3_SHUFFLE_VERSION}.jar"
+
+# SQL
+COPY --from=sql-builder /sql-benchmarks/target/sql-benchmarks-1.0.jar "${SPARK_HOME}/jars/"
+
+USER root
+RUN chmod +r ${SPARK_HOME}/jars/*.jar
+
+USER ${SPARK_USER}

--- a/examples/sql/build.sh
+++ b/examples/sql/build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023- IBM Inc. All rights reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+
+# Make sure you adapt and source ../config.sh first.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "${SCRIPT_DIR}/../../"
+ROOT="$(pwd)/"
+
+REGISTRY="${REGISTRY:-zac32.zurich.ibm.com}"
+PREFIX="${PREFIX:-${USER}}"
+
+IMAGE="${REGISTRY}/${PREFIX}/spark-sql:${SPARK_VERSION}"
+docker build -t "${IMAGE}" \
+    --build-arg SPARK_VERSION=${SPARK_VERSION} \
+    --build-arg S3_SHUFFLE_VERSION=${S3_SHUFFLE_VERSION} \
+    --build-arg HADOOP_VERSION=${HADOOP_VERSION} \
+    --build-arg AWS_SDK_VERSION=${AWS_SDK_VERSION} \
+    -f $SCRIPT_DIR/Dockerfile .
+
+docker push "${IMAGE}"

--- a/examples/sql/run_benchmark.sh
+++ b/examples/sql/run_benchmark.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023- IBM Inc. All rights reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+
+# Make sure you adapt and source ../config.sh first.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "${SCRIPT_DIR}"
+
+ROOT="$(pwd)"
+TIMESTAMP=$(date -u "+%FT%H%M%SZ")
+
+IMAGE="${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}spark-sql:${SPARK_VERSION}"
+
+DRIVER_CPU=${DRIVER_CPU:-4}
+DRIVER_MEM=${DRIVER_MEM:-13000M}
+DRIVER_MEMORY_OVERHEAD=${DRIVER_MEMORY_OVERHEAD:-3000M}
+EXECUTOR_CPU=${EXECUTOR_CPU:-4}
+EXECUTOR_MEM=${EXECUTOR_MEM:-13000M}
+EXECUTOR_MEMORY_OVERHEAD=${EXECUTOR_MEMORY_OVERHEAD:-3000M}
+INSTANCES=${INSTANCES:-4}
+
+EXTRA_CLASSPATHS='/opt/spark/jars/*'
+EXECUTOR_JAVA_OPTIONS="-Dsun.nio.PageAlignDirectMemory=true"
+DRIVER_JAVA_OPTIONS="-Dsun.nio.PageAlignDirectMemory=true"
+
+export SPARK_EXECUTOR_CORES=$EXECUTOR_CPU
+export SPARK_DRIVER_MEMORY=$DRIVER_MEM
+export SPARK_EXECUTOR_MEMORY=$EXECUTOR_MEM
+
+SPARK_HADOOP_S3A_CONFIG=(
+    # Required
+    --conf spark.hadoop.fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem
+    --conf spark.hadoop.fs.s3a.access.key=${S3A_ACCESS_KEY}
+    --conf spark.hadoop.fs.s3a.secret.key=${S3A_SECRET_KEY}
+    --conf spark.hadoop.fs.s3a.connection.ssl.enabled=false
+    --conf spark.hadoop.fs.s3a.endpoint=${S3A_ENDPOINT}
+    --conf spark.hadoop.fs.s3a.path.style.access=true
+    --conf spark.hadoop.fs.s3a.fast.upload=true
+    --conf spark.hadoop.fs.s3a.block.size=$((32*1024*1024))
+)
+
+SPARK_S3_SHUFFLE_CONFIG=(
+    --conf spark.hadoop.fs.s3a.access.key=${S3A_ACCESS_KEY}
+    --conf spark.hadoop.fs.s3a.secret.key=${S3A_SECRET_KEY}
+    --conf spark.hadoop.fs.s3a.endpoint=${S3A_ENDPOINT}
+    --conf spark.shuffle.s3.useBlockManager=${USE_BLOCK_MANAGER:-false}
+    --conf spark.shuffle.manager="org.apache.spark.shuffle.sort.S3ShuffleManager"
+    --conf spark.shuffle.sort.io.plugin.class=org.apache.spark.shuffle.S3ShuffleDataIO
+    --conf spark.shuffle.checksum.enabled=false
+    --conf spark.shuffle.s3.rootDir=${SHUFFLE_DESTINATION}
+)
+
+if (( "$USE_S3_SHUFFLE" == 0 )); then
+    SPARK_S3_SHUFFLE_CONFIG=(
+            --conf spark.shuffle.s3.rootDir=NONE
+    )
+fi
+
+
+${SPARK_HOME}/bin/spark-submit \
+    --master k8s://$KUBERNETES_SERVER \
+    --deploy-mode cluster \
+    \
+        --conf "spark.driver.extraJavaOptions=${DRIVER_JAVA_OPTIONS}" \
+        --conf "spark.executor.extraJavaOptions=${EXECUTOR_JAVA_OPTIONS}" \
+    \
+    --name ce-${PROCESS_TAG}-${INSTANCES}x${EXECUTOR_CPU}--${EXECUTOR_MEM} \
+    --conf spark.serializer="org.apache.spark.serializer.KryoSerializer" \
+    --conf spark.kryoserializer.buffer=128mb \
+    --conf spark.executor.instances=$INSTANCES \
+    "${SPARK_HADOOP_S3A_CONFIG[@]}" \
+    "${SPARK_S3_SHUFFLE_CONFIG[@]}" \
+    --conf spark.ui.prometheus.enabled=true \
+    --conf spark.network.timeout=10000 \
+    --conf spark.executor.heartbeatInterval=20000 \
+    --conf spark.kubernetes.appKillPodDeletionGracePeriod=5 \
+    --conf spark.kubernetes.container.image.pullSecrets=${KUBERNETES_PULL_SECRETS_NAME} \
+    --conf spark.kubernetes.authenticate.driver.serviceAccountName=${KUBERNETES_SERVICE_ACCOUNT} \
+    --conf spark.kubernetes.container.image.pullPolicy=Always \
+    --conf spark.driver.memoryOverhead=$DRIVER_MEMORY_OVERHEAD \
+    --conf spark.kubernetes.driver.request.cores=$DRIVER_CPU \
+    --conf spark.kubernetes.driver.limit.cores=$DRIVER_CPU \
+    --conf spark.executor.memoryOverhead=$EXECUTOR_MEMORY_OVERHEAD \
+    --conf spark.kubernetes.executor.request.cores=$EXECUTOR_CPU \
+    --conf spark.kubernetes.executor.limit.cores=$EXECUTOR_CPU \
+    --conf spark.kubernetes.container.image=$IMAGE \
+    --conf spark.kubernetes.namespace=$KUBERNETES_NAMESPACE \
+    --class com.ibm.crail.benchmarks.Main \
+    local:///opt/spark/jars/sql-benchmarks-1.0.jar \
+    "$@"

--- a/examples/sql/run_single_query.sh
+++ b/examples/sql/run_single_query.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023- IBM Inc. All rights reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+
+# Make sure you adapt and source ../config.sh first.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "${SCRIPT_DIR}"
+ROOT="$(pwd)"
+
+QUERY=$1
+SIZE=${SIZE:-1000}
+TIMESTAMP=$(date -u "+%FT%H%M%SZ")
+PROCESS_TAG=${PROCESS_TAG:-"sql"}
+PROCESS_TAG="${PROCESS_TAG}-${QUERY}-${SIZE}-${TIMESTAMP}"
+
+# Shuffle on S3
+export USE_S3_SHUFFLE=${USE_S3_SHUFFLE:-1}
+
+if (( "${USE_S3_SHUFFLE}" == 1 )); then
+    PROCESS_TAG="${PROCESS_TAG}-s3shuffle"
+fi
+
+export PROCESS_TAG=${PROCESS_TAG}
+
+INPUT_DATA_PREFIX=s3a://${TPCDS_BUCKET}
+OUTPUT_DATA_PREFIX=s3a://${S3A_OUTPUT_BUCKET}/output/sql-benchmarks/
+
+./run_benchmark.sh \
+    -t $QUERY \
+    -i $INPUT_DATA_PREFIX/sf${SIZE}_parquet/ \
+    -a save,${OUTPUT_DATA_PREFIX}/${QUERY}/${PROCESS_TAG}/${SIZE}

--- a/examples/sql/run_tpcds.sh
+++ b/examples/sql/run_tpcds.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023- IBM Inc. All rights reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+
+# Make sure you adapt and source ../config.sh first.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "${SCRIPT_DIR}"
+
+export SIZE=${SIZE:-100}
+export PROCESS_TAG=tpcds
+./run_single_query.sh tpcds

--- a/examples/terasort/Dockerfile
+++ b/examples/terasort/Dockerfile
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023- IBM Inc. All rights reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+
+ARG SPARK_VERSION
+ARG S3_SHUFFLE_VERSION
+ARG HADOOP_VERSION
+ARG AWS_SDK_VERSION
+
+FROM debian:11.5 as java-prerequisites
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+
+RUN apt-get clean && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        openjdk-11-jdk-headless git maven wget \
+    && apt-get clean
+
+###
+# terasort
+FROM java-prerequisites as terasort-builder
+
+RUN git clone https://github.com/ehiggs/spark-terasort \
+    && cd spark-terasort \
+    && git checkout b1e706d506736ab2591a6a34193490e65781c12e \
+    && sed -i 's/3\.0\.1/3\.1\.0/g' pom.xml \
+    && mvn package
+
+# Terasort is now in /spark-terasort/target/spark-terasort-1.2-SNAPSHOT.jar
+
+###
+# S3-Shuffle plugin
+FROM sbtscala/scala-sbt:eclipse-temurin-focal-11.0.17_8_1.9.1_2.12.18 as s3-shuffle-builder
+
+ARG SPARK_VERSION
+ENV SPARK_VERSION=${SPARK_VERSION}
+
+COPY . /spark-s3-shuffle
+RUN cd /spark-s3-shuffle \
+    && sbt package \
+    && ls target/scala-2.12/*
+
+# Result /spark-s3-shuffle/target/scala-2.12/spark-s3-shuffle_2.12-${SPARK_VERSION}_SNAPSHOT.jar 
+
+###
+# Spark Container
+FROM docker.io/apache/spark-py:v${SPARK_VERSION}
+
+ARG SPARK_VERSION
+ARG S3_SHUFFLE_VERSION
+ARG HADOOP_VERSION
+ARG AWS_SDK_VERSION
+
+ADD https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/${HADOOP_VERSION}/hadoop-aws-${HADOOP_VERSION}.jar "${SPARK_HOME}/jars/hadoop-aws-${HADOOP_VERSION}.jar"
+ADD https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/${AWS_SDK_VERSION}/aws-java-sdk-bundle-${AWS_SDK_VERSION}.jar "${SPARK_HOME}/jars/aws-java-sdk-bundle-${AWS_SDK_VERSION}.jar"
+
+# S3-Shuffle plugin
+COPY --from=s3-shuffle-builder /spark-s3-shuffle/target/scala-2.12/spark-s3-shuffle_2.12-${SPARK_VERSION}_SNAPSHOT.jar "${SPARK_HOME}/jars/"
+# Release
+# ADD https://github.com/IBM/spark-s3-shuffle/releases/download/v${S3_SHUFFLE_VERSION}/spark-s3-shuffle_2.12-${SPARK_VERSION}_${S3_SHUFFLE_VERSION}.jar "${SPARK_HOME}/jars/spark-s3-shuffle_2.12-${SPARK_VERSION}_${S3_SHUFFLE_VERSION}.jar"
+
+# TeraSort
+COPY --from=terasort-builder /spark-terasort/target/spark-terasort-1.2-SNAPSHOT.jar "${SPARK_HOME}/jars/"
+
+USER root
+RUN chmod +r ${SPARK_HOME}/jars/*.jar
+
+USER ${SPARK_USER}

--- a/examples/terasort/build.sh
+++ b/examples/terasort/build.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023- IBM Inc. All rights reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+
+# Make sure you adapt and source ../config.sh first.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "${SCRIPT_DIR}/../../"
+ROOT="$(pwd)/"
+
+
+REGISTRY="${REGISTRY:-zac32.zurich.ibm.com}"
+PREFIX="${PREFIX:-${USER}}"
+
+IMAGE="${REGISTRY}/${PREFIX}/spark-terasort:${SPARK_VERSION}"
+docker build -t "${IMAGE}" \
+    --build-arg SPARK_VERSION=${SPARK_VERSION} \
+    --build-arg S3_SHUFFLE_VERSION=${S3_SHUFFLE_VERSION} \
+    --build-arg HADOOP_VERSION=${HADOOP_VERSION} \
+    --build-arg AWS_SDK_VERSION=${AWS_SDK_VERSION} \
+    -f $SCRIPT_DIR/Dockerfile .
+
+docker push "${IMAGE}"

--- a/examples/terasort/run.sh
+++ b/examples/terasort/run.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023- IBM Inc. All rights reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "${SCRIPT_DIR}"
+
+ROOT="$(pwd)"
+TIMESTAMP=$(date -u "+%FT%H%M%SZ")
+
+IMAGE="${DOCKER_REGISTRY}/${DOCKER_IMAGE_PREFIX}spark-terasort:${SPARK_VERSION}"
+
+PROCESS_TAG="-${TIMESTAMP}"
+
+DRIVER_CPU=${DRIVER_CPU:-4}
+DRIVER_MEM=${DRIVER_MEM:-13000M}
+DRIVER_MEMORY_OVERHEAD=${DRIVER_MEMORY_OVERHEAD:-3000M}
+EXECUTOR_CPU=${EXECUTOR_CPU:-4}
+EXECUTOR_MEM=${EXECUTOR_MEM:-13000M}
+EXECUTOR_MEMORY_OVERHEAD=${EXECUTOR_MEMORY_OVERHEAD:-3000M}
+INSTANCES=${INSTANCES:-4}
+SIZE=${SIZE:-1g}
+
+
+# Shuffle on S3
+USE_S3_SHUFFLE=${USE_S3_SHUFFLE:-1}
+
+EXTRA_CLASSPATHS='/opt/spark/jars/*'
+EXECUTOR_JAVA_OPTIONS="-Dsun.nio.PageAlignDirectMemory=true"
+DRIVER_JAVA_OPTIONS="-Dsun.nio.PageAlignDirectMemory=true"
+
+export SPARK_EXECUTOR_CORES=$EXECUTOR_CPU
+export SPARK_DRIVER_MEMORY=$DRIVER_MEM
+export SPARK_EXECUTOR_MEMORY=$EXECUTOR_MEM
+
+
+SPARK_HADOOP_S3A_CONFIG=(
+    # Required
+    --conf spark.hadoop.fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem
+    --conf spark.hadoop.fs.s3a.access.key=${S3A_ACCESS_KEY}
+    --conf spark.hadoop.fs.s3a.secret.key=${S3A_SECRET_KEY}
+    --conf spark.hadoop.fs.s3a.connection.ssl.enabled=false
+    --conf spark.hadoop.fs.s3a.endpoint=${S3A_ENDPOINT}
+    --conf spark.hadoop.fs.s3a.path.style.access=true
+    --conf spark.hadoop.fs.s3a.fast.upload=true
+    --conf spark.hadoop.fs.s3a.block.size=$((32*1024*1024))
+)
+
+
+SPARK_S3_SHUFFLE_CONFIG=(
+    --conf spark.hadoop.fs.s3a.access.key=${S3A_ACCESS_KEY}
+    --conf spark.hadoop.fs.s3a.secret.key=${S3A_SECRET_KEY}
+    --conf spark.hadoop.fs.s3a.endpoint=${S3A_ENDPOINT}
+    --conf spark.shuffle.s3.useBlockManager=${USE_BLOCK_MANAGER:-false}
+    --conf spark.shuffle.manager="org.apache.spark.shuffle.sort.S3ShuffleManager"
+    --conf spark.shuffle.sort.io.plugin.class=org.apache.spark.shuffle.S3ShuffleDataIO
+    --conf spark.shuffle.checksum.enabled=false
+    --conf spark.shuffle.s3.rootDir=${SHUFFLE_DESTINATION}
+)
+
+if (( "$USE_S3_SHUFFLE" == 0 )); then
+    SPARK_S3_SHUFFLE_CONFIG=(
+            --conf spark.shuffle.s3.rootDir=${SHUFFLE_DESTINATION}
+    )
+else
+    PROCESS_TAG="${PROCESS_TAG}-s3shuffle"
+fi
+
+${SPARK_HOME}/bin/spark-submit \
+    --master k8s://$KUBERNETES_SERVER \
+    --deploy-mode cluster \
+    \
+        --conf "spark.driver.extraJavaOptions=${DRIVER_JAVA_OPTIONS}" \
+        --conf "spark.executor.extraJavaOptions=${EXECUTOR_JAVA_OPTIONS}" \
+    \
+    --name ce-terasort-${SIZE}${PROCESS_TAG}-${INSTANCES}x${EXECUTOR_CPU}--${EXECUTOR_MEM} \
+    --conf spark.serializer="org.apache.spark.serializer.KryoSerializer" \
+    --conf spark.kryoserializer.buffer=128mb \
+    --conf spark.executor.instances=$INSTANCES \
+    "${SPARK_HADOOP_S3A_CONFIG[@]}" \
+    "${SPARK_S3_SHUFFLE_CONFIG[@]}" \
+    --conf spark.ui.prometheus.enabled=true \
+    --conf spark.network.timeout=10000 \
+    --conf spark.executor.heartbeatInterval=20000 \
+    --conf spark.kubernetes.appKillPodDeletionGracePeriod=5 \
+    --conf spark.kubernetes.container.image.pullSecrets=${KUBERNETES_PULL_SECRETS_NAME} \
+    --conf spark.kubernetes.authenticate.driver.serviceAccountName=${KUBERNETES_SERVICE_ACCOUNT} \
+    --conf spark.kubernetes.container.image.pullPolicy=Always \
+    --conf spark.driver.memoryOverhead=$DRIVER_MEMORY_OVERHEAD \
+    --conf spark.kubernetes.driver.request.cores=$DRIVER_CPU \
+    --conf spark.kubernetes.driver.limit.cores=$DRIVER_CPU \
+    --conf spark.executor.memoryOverhead=$EXECUTOR_MEMORY_OVERHEAD \
+    --conf spark.kubernetes.executor.request.cores=$EXECUTOR_CPU \
+    --conf spark.kubernetes.executor.limit.cores=$EXECUTOR_CPU \
+    --conf spark.kubernetes.container.image=$IMAGE \
+    --conf spark.kubernetes.namespace=$KUBERNETES_NAMESPACE \
+    --class com.github.ehiggs.spark.terasort.TeraSort \
+    local:///opt/spark/jars/spark-terasort-1.2-SNAPSHOT.jar \
+    "s3a://${TERASORT_BUCKET}/${SIZE}" "s3a://${S3A_OUTPUT_BUCKET}/output/terasort/${SIZE}-${PROCESS_TAG}"
+
+${SPARK_HOME}/bin/spark-submit \
+    --master k8s://$KUBERNETES_SERVER \
+    --deploy-mode cluster \
+    \
+        --conf "spark.driver.extraJavaOptions=${DRIVER_JAVA_OPTIONS}" \
+        --conf "spark.executor.extraJavaOptions=${EXECUTOR_JAVA_OPTIONS}" \
+    \
+    --name ce-teravalidate-${SIZE}-${PROCESS_TAG}-${INSTANCES}x${EXECUTOR_CPU}--${EXECUTOR_MEM} \
+    --conf spark.executor.instances=$INSTANCES \
+    --conf spark.jars.ivy=/tmp/.ivy \
+    --conf spark.serializer=org.apache.spark.serializer.KryoSerializer \
+    --conf spark.kryoserializer.buffer=128mb \
+    "${SPARK_HADOOP_S3A_CONFIG[@]}" \
+    --conf spark.ui.prometheus.enabled=true \
+    --conf spark.network.timeout=10000 \
+    --conf spark.executor.heartbeatInterval=20000 \
+    --conf spark.kubernetes.appKillPodDeletionGracePeriod=5 \
+    --conf spark.kubernetes.container.image.pullSecrets=${KUBERNETES_PULL_SECRETS_NAME} \
+    --conf spark.kubernetes.authenticate.driver.serviceAccountName=${KUBERNETES_SERVICE_ACCOUNT} \
+    --conf spark.kubernetes.container.image.pullPolicy=Always \
+    --conf spark.driver.memoryOverhead=$DRIVER_MEMORY_OVERHEAD \
+    --conf spark.kubernetes.driver.request.cores=$DRIVER_CPU \
+    --conf spark.kubernetes.driver.limit.cores=$DRIVER_CPU \
+    --conf spark.kubernetes.executor.request.cores=$EXECUTOR_CPU \
+    --conf spark.kubernetes.executor.limit.cores=$EXECUTOR_CPU \
+    --conf spark.executor.memoryOverhead=$EXECUTOR_MEMORY_OVERHEAD \
+    --conf spark.kubernetes.container.image=$IMAGE \
+    --conf spark.kubernetes.namespace=$KUBERNETES_NAMESPACE \
+    --class com.github.ehiggs.spark.terasort.TeraValidate \
+    local:///opt/spark/jars/spark-terasort-1.2-SNAPSHOT.jar \
+       "s3a://${S3A_OUTPUT_BUCKET}/output/terasort/${SIZE}-${PROCESS_TAG}" "s3a://${S3A_OUTPUT_BUCKET}/output/terasort-validated/${SIZE}-${PROCESS_TAG}"
+
+s3cmd rm -r s3://${S3A_OUTPUT_BUCKET}/output/terasort/${SIZE}-${PROCESS_TAG} || true

--- a/src/main/scala/org/apache/spark/shuffle/helper/S3ShuffleDispatcher.scala
+++ b/src/main/scala/org/apache/spark/shuffle/helper/S3ShuffleDispatcher.scala
@@ -34,8 +34,8 @@ class S3ShuffleDispatcher extends Logging {
   val alwaysCreateIndex: Boolean = conf.getBoolean("spark.shuffle.s3.alwaysCreateIndex", defaultValue = false)
   val useBlockManager: Boolean = conf.getBoolean("spark.shuffle.s3.useBlockManager", defaultValue = true)
   val forceBatchFetch: Boolean = conf.getBoolean("spark.shuffle.s3.forceBatchFetch", defaultValue = false)
-  val prefetchBatchSize: Int = conf.getInt("spark.shuffle.s3.prefetchBatchSize", defaultValue = 10)
-  val prefetchThreadPoolSize: Int = conf.getInt("spark.shuffle.s3.prefetchThreadPoolSize", defaultValue = 20)
+  val prefetchBatchSize: Int = conf.getInt("spark.shuffle.s3.prefetchBatchSize", defaultValue = 25)
+  val prefetchThreadPoolSize: Int = conf.getInt("spark.shuffle.s3.prefetchThreadPoolSize", defaultValue = 100)
 
   val appDir = f"/${startTime}-${appId}/"
   val fs: FileSystem = FileSystem.get(URI.create(rootDir), {

--- a/src/main/scala/org/apache/spark/storage/S3ShuffleBlockStream.scala
+++ b/src/main/scala/org/apache/spark/storage/S3ShuffleBlockStream.scala
@@ -25,10 +25,7 @@ class S3ShuffleBlockStream(
   private lazy val blockId = ShuffleDataBlockId(shuffleId, mapId, NOOP_REDUCE_ID)
   private lazy val stream = {
     try {
-      if (dispatcher.supportsUnbuffer)
-        dispatcher.openCachedBlock(blockId)
-      else
-        dispatcher.openBlock(blockId)
+      dispatcher.openBlock(blockId)
     } catch {
       case throwable: Throwable =>
         logError(f"Unable to open block ${blockId.name}")
@@ -50,13 +47,8 @@ class S3ShuffleBlockStream(
       return
     }
     this.synchronized {
-      if (dispatcher.supportsUnbuffer) {
-        stream.unbuffer()
-        streamClosed = true
-      } else {
-        stream.close()
-        streamClosed = true
-      }
+      stream.close()
+      streamClosed = true
     }
     super.close()
   }


### PR DESCRIPTION
- Fix timeout issue by disabling unbuffer (not support with Hadoop 3.2.0)
- Revert threadpool defaults.
- Add examples.