### PR TITLE
Disable caching when listing shuffle indices.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ Configuration options used for debugging:
 
 - `spark.shuffle.s3.useBlockManager`: Use the Spark block manager to compute blocks (default: `true`).
 
-  **Note**: Disabling this feature might lead to invalid results. Only use if all the Shuffle operations require a
-  barrier.
+  **Note**: Disabling this feature uses the file system listing to determine which shuffle blocks should be read.
 
 - `spark.shuffle.s3.forceBatchFetch`: Force batch fetch for Shuffle Blocks (default: `false`)
 

--- a/src/main/scala/org/apache/spark/storage/S3ShuffleReader.scala
+++ b/src/main/scala/org/apache/spark/storage/S3ShuffleReader.scala
@@ -191,7 +191,7 @@ class S3ShuffleReader[K, C](
                      .flatMap(info => ShuffleBlockFetcherIterator.mergeContinuousShuffleBlockIdsIfNeeded(info, doBatchFetch))
                      .map(_.blockId)
     } else {
-      val indices = S3ShuffleHelper.listShuffleIndicesCached(shuffleId).filter(
+      val indices = S3ShuffleHelper.listShuffleIndices(shuffleId).filter(
         block => block.mapId >= startMapIndex && block.mapId < endMapIndex)
       if (doBatchFetch || dispatcher.forceBatchFetch) {
         indices.map(block => ShuffleBlockBatchId(block.shuffleId, block.mapId, startPartition, endPartition)).toIterator


### PR DESCRIPTION
Reason: In some cases Spark does not invoke a barrier. In these cases the cache contains stale data.