### PR TITLE
Register blocks in FallbackStorage by default to avoid the `MetadataFetchFailedException`.

### DIFF
--- a/src/main/scala/org/apache/spark/shuffle/S3ShuffleWriter.scala
+++ b/src/main/scala/org/apache/spark/shuffle/S3ShuffleWriter.scala
@@ -1,0 +1,22 @@
+package org.apache.spark.shuffle
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.scheduler.MapStatus
+import org.apache.spark.storage.FallbackStorage
+
+class S3ShuffleWriter[K, V](writer: ShuffleWriter[K, V]) extends ShuffleWriter[K, V] with Logging {
+  override def write(records: Iterator[Product2[K, V]]): Unit = writer.write(records)
+
+  override def stop(success: Boolean): Option[MapStatus] = {
+    val message = writer.stop(success)
+    if (message.isEmpty) {
+      return message
+    }
+    val status = message.get
+    status.updateLocation(FallbackStorage.FALLBACK_BLOCK_MANAGER_ID)
+    Option(status)
+  }
+
+  override def getPartitionLengths(): Array[Long] = writer.getPartitionLengths()
+}
+

--- a/src/main/scala/org/apache/spark/shuffle/sort/S3ShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/sort/S3ShuffleManager.scala
@@ -103,7 +103,7 @@ private[spark] class S3ShuffleManager(conf: SparkConf) extends ShuffleManager wi
                                 context: TaskContext,
                                 metrics: ShuffleWriteMetricsReporter): ShuffleWriter[K, V] = {
     val env = SparkEnv.get
-    handle match {
+    val writer = handle match {
       case unsafeShuffleHandle: SerializedShuffleHandle[K@unchecked, V@unchecked] =>
         new UnsafeShuffleWriter(
           env.blockManager,
@@ -126,6 +126,7 @@ private[spark] class S3ShuffleManager(conf: SparkConf) extends ShuffleManager wi
       case other: BaseShuffleHandle[K@unchecked, V@unchecked, _] =>
         new SortShuffleWriter(other, mapId, context, shuffleExecutorComponents)
     }
+    new S3ShuffleWriter[K, V](writer)
   }
 
   def purgeCaches(shuffleId: Int): Unit = {


### PR DESCRIPTION
This PR registers all shuffle blocks with the fall back storage to avoid the Spark `MetadataFetchFailedException`:

```
23/07/28 11:20:59 WARN TaskSetManager: Lost task 65.0 in stage 1.0 (TID 397) (10.244.12.115 executor 6): FetchFailed(null, shuffleId=0, mapIndex=-1, mapId=-1, reduceId=65, message=
org.apache.spark.shuffle.MetadataFetchFailedException: Missing an output location for shuffle 0 partition 65
	at org.apache.spark.MapOutputTracker$.validateStatus(MapOutputTracker.scala:1705)
	at org.apache.spark.MapOutputTracker$.$anonfun$convertMapStatuses$10(MapOutputTracker.scala:1652)
	at org.apache.spark.MapOutputTracker$.$anonfun$convertMapStatuses$10$adapted(MapOutputTracker.scala:1651)
	at scala.collection.Iterator.foreach(Iterator.scala:943)
	at scala.collection.Iterator.foreach$(Iterator.scala:943)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
	at org.apache.spark.MapOutputTracker$.convertMapStatuses(MapOutputTracker.scala:1651)
	at org.apache.spark.MapOutputTrackerWorker.getMapSizesByExecutorIdImpl(MapOutputTracker.scala:1294)
	at org.apache.spark.MapOutputTrackerWorker.getMapSizesByExecutorId(MapOutputTracker.scala:1256)
	at org.apache.spark.storage.S3ShuffleReader.computeShuffleBlocks(S3ShuffleReader.scala:189)
	at org.apache.spark.storage.S3ShuffleReader.read(S3ShuffleReader.scala:97)
	at org.apache.spark.rdd.ShuffledRDD.compute(ShuffledRDD.scala:106)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:365)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:329)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:136)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:548)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1504)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:551)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```