### PR TITLE
Fix S3A timeout issue and avoid memory leak.

### DIFF
--- a/src/main/scala/org/apache/spark/shuffle/helper/S3ShuffleHelper.scala
+++ b/src/main/scala/org/apache/spark/shuffle/helper/S3ShuffleHelper.scala
@@ -118,6 +118,7 @@ object S3ShuffleHelper extends Logging {
     for (pos <- 0 until count) {
       result(pos) = input.readLong()
     }
+    input.close()
     result
   }
 }


### PR DESCRIPTION
Background: The open file triggered a timeout in the S3A connection pool.