### PR TITLE
WIP: Add support for Spark 4 (might deprecate Scala 2.12 builds and Spark 3.xx)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,16 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - spark: 3.4.4
-            scala: 2.12.17
+#          - spark: 3.4.4
+#            scala: 2.12.17
           - spark: 3.4.4
             scala: 2.13.8
-          - spark: 3.5.2
-            scala: 2.12.18
+#          - spark: 3.5.2
+#            scala: 2.12.18
           - spark: 3.5.2
             scala: 2.13.8
-          - spark: 3.5.5
-            scala: 2.12.17
+#          - spark: 3.5.5
+#            scala: 2.12.17
           - spark: 3.5.5
             scala: 2.13.8
           - spark: 4.0.0-preview2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,41 +17,17 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - spark: 3.2.0
-            scala: 2.12.15
-          - spark: 3.2.0
-            scala: 2.13.5
-          - spark: 3.2.1
-            scala: 2.12.15
-          - spark: 3.2.1
-            scala: 2.13.5
-          - spark: 3.2.3
-            scala: 2.12.15
-          - spark: 3.2.3
-            scala: 2.13.5
-          - spark: 3.2.4
-            scala: 2.12.15
-          - spark: 3.2.4
-            scala: 2.13.5
-          - spark: 3.3.0
-            scala: 2.12.15
-          - spark: 3.3.0
-            scala: 2.13.8
-          - spark: 3.3.1
-            scala: 2.12.15
-          - spark: 3.3.1
-            scala: 2.13.8
-          - spark: 3.3.2
-            scala: 2.12.15
-          - spark: 3.3.2
-            scala: 2.13.8
-          - spark: 3.4.0
+          - spark: 3.4.4
             scala: 2.12.17
-          - spark: 3.4.0
+          - spark: 3.4.4
             scala: 2.13.8
-          - spark: 3.5.0
+          - spark: 3.5.2
             scala: 2.12.18
-          - spark: 3.5.0
+          - spark: 3.5.2
+            scala: 2.13.8
+          - spark: 3.5.5
+            scala: 2.12.17
+          - spark: 3.5.5
             scala: 2.13.8
           - spark: 4.0.0-preview2
             scala: 2.13.16

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,19 +31,20 @@ jobs:
             scala: 2.13.8
           - spark: 4.0.0-preview2
             scala: 2.13.16
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # Newer versions of Ubuntu require a dedicated sbt installation step.
     env:
       SPARK_VERSION: ${{ matrix.spark }}
       SCALA_VERSION: ${{ matrix.scala }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Setup JDK
-      uses: actions/setup-java@v3
+      # https://github.com/actions/setup-java?tab=readme-ov-file#caching-sbt-dependencies
+      uses: actions/setup-java@v4
       with:
-        distribution: temurin
-        java-version: 11
-        cache: sbt
+        distribution: 'temurin'
+        java-version: '17'
+        cache: 'sbt'
     - name: Check formatting
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
             scala: 2.12.18
           - spark: 3.5.0
             scala: 2.13.8
+          - spark: 4.0.0-preview2
+            scala: 2.13.16
     runs-on: ubuntu-latest
     env:
       SPARK_VERSION: ${{ matrix.spark }}

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ to Java > 11:
   --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
   --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
   --add-opens=java.base/sun.nio.cs=ALL-UNNAMED
-  --add-opens=java.base/sun.security.action=ALL-UNNAMED -
-  -add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+  --add-opens=java.base/sun.security.action=ALL-UNNAMED 
+  --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
   --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache2.0
 //
 
-scalaVersion := sys.env.getOrElse("SCALA_VERSION", "2.12.15")
+scalaVersion := sys.env.getOrElse("SCALA_VERSION", "2.13.16")
 organization := "com.ibm"
 name := "spark-s3-shuffle"
-val sparkVersion = sys.env.getOrElse("SPARK_VERSION", "3.3.1")
+val sparkVersion = sys.env.getOrElse("SPARK_VERSION", "4.0.0-preview2")
 
 enablePlugins(GitVersioning, BuildInfoPlugin)
 
@@ -29,20 +29,9 @@ buildInfoKeys ++= Seq[BuildInfoKey](
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
   "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
-  "org.apache.spark" %% "spark-hadoop-cloud" % sparkVersion % "compile"
+  "org.apache.spark" %% "spark-hadoop-cloud" % sparkVersion % "compile",
+  "org.scalatest" %% "scalatest" % "3.2.19" % Test
 )
-
-libraryDependencies ++= (if (scalaBinaryVersion.value == "2.12")
-                           Seq(
-                             "junit" % "junit" % "4.13.2" % Test,
-                             "org.scalatest" %% "scalatest" % "3.2.2" % Test,
-                             "ch.cern.sparkmeasure" %% "spark-measure" % "0.18" % Test,
-                             "org.scalacheck" %% "scalacheck" % "1.15.2" % Test,
-                             "org.mockito" % "mockito-core" % "3.4.6" % Test,
-                             "org.scalatestplus" %% "mockito-3-4" % "3.2.9.0" % Test,
-                             "com.github.sbt" % "junit-interface" % "0.13.3" % Test
-                           )
-                         else Seq())
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:MaxPermSize=2048M", "-XX:+CMSClassUnloadingEnabled")

--- a/src/main/scala/org/apache/spark/shuffle/ConcurrentObjectMap.scala
+++ b/src/main/scala/org/apache/spark/shuffle/ConcurrentObjectMap.scala
@@ -38,7 +38,7 @@ class ConcurrentObjectMap[K, V] {
 
   def remove(filter: (K) => Boolean, action: Option[(V) => Unit]): Unit = {
     lock.synchronized {
-      val keys = valueLocks.filterKeys(filter)
+      val keys = valueLocks.view.filterKeys(filter)
       keys.foreach(v => {
         val key = v._1
         val l = v._2

--- a/src/main/scala/org/apache/spark/shuffle/helper/S3ShuffleDispatcher.scala
+++ b/src/main/scala/org/apache/spark/shuffle/helper/S3ShuffleDispatcher.scala
@@ -223,14 +223,9 @@ class S3ShuffleDispatcher extends Logging {
         case ShuffleMergedDataBlockId(_, shuffleId, _, _)  => shuffleId == shuffleIndex
         case ShuffleMergedIndexBlockId(_, shuffleId, _, _) => shuffleId == shuffleIndex
         case ShuffleMergedMetaBlockId(_, shuffleId, _, _)  => shuffleId == shuffleIndex
-        case BroadcastBlockId(_, _)                        => false
-        case TaskResultBlockId(_)                          => false
-        case StreamBlockId(_, _)                           => false
-        case TempLocalBlockId(_)                           => false
-        case TempShuffleBlockId(_)                         => false
-        case TestBlockId(_)                                => false
+        case _                                             => false
       }
-    cachedFileStatus.remove(filter, _)
+    cachedFileStatus.remove(filter, None)
   }
 
   /** Open a block for writing.

--- a/src/main/scala/org/apache/spark/shuffle/helper/S3ShuffleHelper.scala
+++ b/src/main/scala/org/apache/spark/shuffle/helper/S3ShuffleHelper.scala
@@ -1,6 +1,6 @@
 package org.apache.spark.shuffle.helper
 
-import org.apache.spark.{SparkException}
+import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.shuffle.ConcurrentObjectMap
 import org.apache.spark.shuffle.IndexShuffleBlockResolver.NOOP_REDUCE_ID

--- a/src/main/scala/org/apache/spark/shuffle/sort/S3ShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/sort/S3ShuffleManager.scala
@@ -145,7 +145,7 @@ private[spark] class S3ShuffleManager(conf: SparkConf) extends ShuffleManager wi
           shuffleExecutorComponents
         )
       case other: BaseShuffleHandle[K @unchecked, V @unchecked, _] =>
-        new SortShuffleWriter(other, mapId, context, shuffleExecutorComponents)
+        new SortShuffleWriter(other, mapId, context, metrics, shuffleExecutorComponents)
     }
     new S3ShuffleWriter[K, V](writer)
   }

--- a/src/main/scala/org/apache/spark/shuffle/sort/S3ShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/sort/S3ShuffleManager.scala
@@ -31,12 +31,8 @@ import org.apache.spark.shuffle.api.ShuffleExecutorComponents
 import org.apache.spark.shuffle.helper.{S3ShuffleDispatcher, S3ShuffleHelper}
 import org.apache.spark.storage.S3ShuffleReader
 
-import java.io.IOException
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, Future}
 
 /** This class was adapted from Apache Spark: SortShuffleManager.scala
   */

--- a/src/main/scala/org/apache/spark/storage/S3BufferedPrefetchIterator.scala
+++ b/src/main/scala/org/apache/spark/storage/S3BufferedPrefetchIterator.scala
@@ -9,7 +9,7 @@ import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.shuffle.helper.S3ShuffleDispatcher
 
-import java.io.{BufferedInputStream, InputStream}
+import java.io.InputStream
 import java.util
 import java.util.concurrent.atomic.AtomicLong
 

--- a/src/main/scala/org/apache/spark/storage/S3ShuffleReader.scala
+++ b/src/main/scala/org/apache/spark/storage/S3ShuffleReader.scala
@@ -183,7 +183,7 @@ class S3ShuffleReader[K, C](
         .listShuffleIndices(shuffleId)
         .filter(block => block.mapId >= startMapIndex && block.mapId < endMapIndex)
       if (doBatchFetch || dispatcher.forceBatchFetch) {
-        indices.map(block => ShuffleBlockBatchId(block.shuffleId, block.mapId, startPartition, endPartition)).toIterator
+        indices.map(block => ShuffleBlockBatchId(block.shuffleId, block.mapId, startPartition, endPartition)).iterator
       } else {
         indices
           .flatMap(block =>
@@ -191,7 +191,7 @@ class S3ShuffleReader[K, C](
               ShuffleBlockId(block.shuffleId, block.mapId, partition)
             )
           )
-          .toIterator
+          .iterator
       }
     }
   }

--- a/src/test/scala/org/apache/spark/shuffle/S3ShuffleManagerTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/S3ShuffleManagerTest.scala
@@ -23,10 +23,7 @@
 package org.apache.spark.shuffle
 
 import org.apache.spark._
-import org.apache.spark.sql.SparkSession
-import org.scalatest._
 import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
 
 import java.util.UUID
 


### PR DESCRIPTION
I'm adding support for Spark 4, by migrating the tests to Scalatest and fixing Scala 2.13 deprecations.
I also fixed a documentation bug in the README.

I also found a potential bug in the S3ShuffleDispatcher:

```
[warn] /Users/pascal/Code/spark-s3-shuffle/src/main/scala/org/apache/spark/shuffle/helper/S3ShuffleDispatcher.scala:233:28: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
[warn]     cachedFileStatus.remove(filter,_)
[warn]                            ^
```

Which I replaced with `cachedFileStatus.remove(filter, None)` which should not be removed by the scala compiler.