### PR TITLE
Fix GithubCI build and breaking change in SortShuffleWriter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             scala: 2.12.18
           - spark: 3.5.0
             scala: 2.13.8
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # Upgrading this version requires an additional sbt setup step.
     env:
       SPARK_VERSION: ${{ matrix.spark }}
       SCALA_VERSION: ${{ matrix.scala }}
@@ -72,14 +72,14 @@ jobs:
         echo "If either of these checks fail run: 'sbt scalafmtAll && sbt scalafmtSbt'"
         sbt scalafmtSbtCheck
         sbt scalafmtCheckAll
-    - name: Test Default Shuffle Fetch
+    - name: Run tests
+      if: startsWith(matrix.scala, '2.')
       shell: bash
-      if: startsWith(matrix.scala, '2.12.')
       run: |
         sbt test
-    - name: Test Spark Shuffle Fetch
+    - name: Run tests with Spark Shuffle Fetch enabled
       shell: bash
-      if: startsWith(matrix.scala, '2.12.') && !startsWith(matrix.spark, '3.2.')
+      if: !startsWith(matrix.spark, '3.2.')
       env:
         USE_SPARK_SHUFFLE_FETCH: "true"
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,14 @@ jobs:
       SCALA_VERSION: ${{ matrix.scala }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Setup JDK
-      uses: actions/setup-java@v3
+      # https://github.com/actions/setup-java?tab=readme-ov-file#caching-sbt-dependencies
+      uses: actions/setup-java@v4
       with:
-        distribution: temurin
-        java-version: 11
-        cache: sbt
+        distribution: 'temurin'
+        java-version: '17'
+        cache: 'sbt'
     - name: Check formatting
       shell: bash
       run: |-
@@ -74,6 +75,8 @@ jobs:
         sbt scalafmtCheckAll
     - name: Run tests
       shell: bash
+      env:
+        JAVA_OPTS: "--add-opens=java.base/java.lang=ALL-UNNAME --add-opens=java.base/java.lang.invoke=ALL-UNNAME --add-opens=java.base/java.lang.reflect=ALL-UNNAME --add-opens=java.base/java.io=ALL-UNNAME --add-opens=java.base/java.net=ALL-UNNAME --add-opens=java.base/java.nio=ALL-UNNAME --add-opens=java.base/java.util=ALL-UNNAME --add-opens=java.base/java.util.concurrent=ALL-UNNAME --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAME --add-opens=java.base/sun.nio.ch=ALL-UNNAME --add-opens=java.base/sun.nio.cs=ALL-UNNAME --add-opens=java.base/sun.security.action=ALL-UNNAME --add-opens=java.base/sun.util.calendar=ALL-UNNAME --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAME"
       run: |
         sbt test
     - name: Run tests with Spark Shuffle Fetch enabled

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Run tests
       shell: bash
       env:
-        JAVA_OPTS: "--add-opens=java.base/java.lang=ALL-UNNAME --add-opens=java.base/java.lang.invoke=ALL-UNNAME --add-opens=java.base/java.lang.reflect=ALL-UNNAME --add-opens=java.base/java.io=ALL-UNNAME --add-opens=java.base/java.net=ALL-UNNAME --add-opens=java.base/java.nio=ALL-UNNAME --add-opens=java.base/java.util=ALL-UNNAME --add-opens=java.base/java.util.concurrent=ALL-UNNAME --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAME --add-opens=java.base/sun.nio.ch=ALL-UNNAME --add-opens=java.base/sun.nio.cs=ALL-UNNAME --add-opens=java.base/sun.security.action=ALL-UNNAME --add-opens=java.base/sun.util.calendar=ALL-UNNAME --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAME"
+        JAVA_OPTS: "--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED  --add-opens=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED --add-opens=java.base/javax.security.auth=ALL-UNNAMED"
       run: |
         sbt test
     - name: Run tests with Spark Shuffle Fetch enabled
@@ -60,6 +60,7 @@ jobs:
       if: ${{ !startsWith(matrix.spark, '3.2.') }}
       env:
         USE_SPARK_SHUFFLE_FETCH: "true"
+        JAVA_OPTS: "--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED  --add-opens=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED --add-opens=java.base/javax.security.auth=ALL-UNNAMED"
       run: |
         sbt test
     - name: Package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,18 +68,17 @@ jobs:
         cache: sbt
     - name: Check formatting
       shell: bash
-      run: |
+      run: |-
         echo "If either of these checks fail run: 'sbt scalafmtAll && sbt scalafmtSbt'"
         sbt scalafmtSbtCheck
         sbt scalafmtCheckAll
     - name: Run tests
-      if: startsWith(matrix.scala, '2.')
       shell: bash
       run: |
         sbt test
     - name: Run tests with Spark Shuffle Fetch enabled
       shell: bash
-      if: !startsWith(matrix.spark, '3.2.')
+      if: ${{ !startsWith(matrix.spark, '3.2.') }}
       env:
         USE_SPARK_SHUFFLE_FETCH: "true"
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,43 +17,19 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - spark: 3.2.0
-            scala: 2.12.15
-          - spark: 3.2.0
-            scala: 2.13.5
-          - spark: 3.2.1
-            scala: 2.12.15
-          - spark: 3.2.1
-            scala: 2.13.5
-          - spark: 3.2.3
-            scala: 2.12.15
-          - spark: 3.2.3
-            scala: 2.13.5
-          - spark: 3.2.4
-            scala: 2.12.15
-          - spark: 3.2.4
-            scala: 2.13.5
-          - spark: 3.3.0
-            scala: 2.12.15
-          - spark: 3.3.0
-            scala: 2.13.8
-          - spark: 3.3.1
-            scala: 2.12.15
-          - spark: 3.3.1
-            scala: 2.13.8
-          - spark: 3.3.2
-            scala: 2.12.15
-          - spark: 3.3.2
-            scala: 2.13.8
-          - spark: 3.4.0
-            scala: 2.12.17
-          - spark: 3.4.0
-            scala: 2.13.8
-          - spark: 3.5.0
-            scala: 2.12.18
-          - spark: 3.5.0
-            scala: 2.13.8
-    runs-on: ubuntu-22.04 # Upgrading this version requires an additional sbt setup step.
+        - spark: 3.4.4
+          scala: 2.12.17
+        - spark: 3.4.4
+          scala: 2.13.8
+        - spark: 3.5.2
+          scala: 2.12.18
+        - spark: 3.5.2
+          scala: 2.13.8
+        - spark: 3.5.5
+          scala: 2.12.18
+        - spark: 3.5.5
+          scala: 2.13.8
+    runs-on: ubuntu-22.04
     env:
       SPARK_VERSION: ${{ matrix.spark }}
       SCALA_VERSION: ${{ matrix.scala }}

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ to Java > 11:
   --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
   --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
   --add-opens=java.base/sun.nio.cs=ALL-UNNAMED
-  --add-opens=java.base/sun.security.action=ALL-UNNAMED -
-  -add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+  --add-opens=java.base/sun.security.action=ALL-UNNAMED 
+  --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
   --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache2.0
 //
 
-scalaVersion := sys.env.getOrElse("SCALA_VERSION", "2.12.15")
+scalaVersion := sys.env.getOrElse("SCALA_VERSION", "2.12.18")
 organization := "com.ibm"
 name := "spark-s3-shuffle"
-val sparkVersion = sys.env.getOrElse("SPARK_VERSION", "3.3.1")
+val sparkVersion = sys.env.getOrElse("SPARK_VERSION", "3.5.0")
 
 enablePlugins(GitVersioning, BuildInfoPlugin)
 
@@ -29,20 +29,9 @@ buildInfoKeys ++= Seq[BuildInfoKey](
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
   "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
-  "org.apache.spark" %% "spark-hadoop-cloud" % sparkVersion % "compile"
+  "org.apache.spark" %% "spark-hadoop-cloud" % sparkVersion % "compile",
+  "org.scalatest" %% "scalatest" % "3.2.19" % Test
 )
-
-libraryDependencies ++= (if (scalaBinaryVersion.value == "2.12")
-                           Seq(
-                             "junit" % "junit" % "4.13.2" % Test,
-                             "org.scalatest" %% "scalatest" % "3.2.2" % Test,
-                             "ch.cern.sparkmeasure" %% "spark-measure" % "0.18" % Test,
-                             "org.scalacheck" %% "scalacheck" % "1.15.2" % Test,
-                             "org.mockito" % "mockito-core" % "3.4.6" % Test,
-                             "org.scalatestplus" %% "mockito-3-4" % "3.2.9.0" % Test,
-                             "com.github.sbt" % "junit-interface" % "0.13.3" % Test
-                           )
-                         else Seq())
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:MaxPermSize=2048M", "-XX:+CMSClassUnloadingEnabled")

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@
 scalaVersion := sys.env.getOrElse("SCALA_VERSION", "2.12.18")
 organization := "com.ibm"
 name := "spark-s3-shuffle"
-val sparkVersion = sys.env.getOrElse("SPARK_VERSION", "3.5.0")
+val sparkVersion = sys.env.getOrElse("SPARK_VERSION", "3.5.5")
 
 enablePlugins(GitVersioning, BuildInfoPlugin)
 

--- a/src/main/scala/org/apache/spark/shuffle/helper/S3ShuffleDispatcher.scala
+++ b/src/main/scala/org/apache/spark/shuffle/helper/S3ShuffleDispatcher.scala
@@ -211,7 +211,6 @@ class S3ShuffleDispatcher extends Logging {
   def closeCachedBlocks(shuffleIndex: Int): Unit = {
     val filter = (blockId: BlockId) =>
       blockId match {
-        case RDDBlockId(_, _)                              => false
         case ShuffleBlockId(shuffleId, _, _)               => shuffleId == shuffleIndex
         case ShuffleBlockBatchId(shuffleId, _, _, _)       => shuffleId == shuffleIndex
         case ShuffleBlockChunkId(shuffleId, _, _, _)       => shuffleId == shuffleIndex
@@ -223,14 +222,9 @@ class S3ShuffleDispatcher extends Logging {
         case ShuffleMergedDataBlockId(_, shuffleId, _, _)  => shuffleId == shuffleIndex
         case ShuffleMergedIndexBlockId(_, shuffleId, _, _) => shuffleId == shuffleIndex
         case ShuffleMergedMetaBlockId(_, shuffleId, _, _)  => shuffleId == shuffleIndex
-        case BroadcastBlockId(_, _)                        => false
-        case TaskResultBlockId(_)                          => false
-        case StreamBlockId(_, _)                           => false
-        case TempLocalBlockId(_)                           => false
-        case TempShuffleBlockId(_)                         => false
-        case TestBlockId(_)                                => false
+        case _                                             => false
       }
-    cachedFileStatus.remove(filter, _)
+    cachedFileStatus.remove(filter, None)
   }
 
   /** Open a block for writing.

--- a/src/main/scala/org/apache/spark/shuffle/sort/S3ShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/sort/S3ShuffleManager.scala
@@ -23,20 +23,15 @@
 package org.apache.spark.shuffle.sort
 
 import com.ibm.SparkS3ShuffleBuild
-import org.apache.hadoop.fs.{Path, PathFilter}
 import org.apache.spark._
-import org.apache.spark.internal.{Logging, config}
+import org.apache.spark.internal.Logging
 import org.apache.spark.shuffle._
 import org.apache.spark.shuffle.api.ShuffleExecutorComponents
 import org.apache.spark.shuffle.helper.{S3ShuffleDispatcher, S3ShuffleHelper}
 import org.apache.spark.storage.S3ShuffleReader
 
-import java.io.IOException
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, Future}
 
 /** This class was adapted from Apache Spark: SortShuffleManager.scala
   */

--- a/src/main/scala/org/apache/spark/shuffle/sort/S3ShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/sort/S3ShuffleManager.scala
@@ -140,7 +140,7 @@ private[spark] class S3ShuffleManager(conf: SparkConf) extends ShuffleManager wi
           shuffleExecutorComponents
         )
       case other: BaseShuffleHandle[K @unchecked, V @unchecked, _] =>
-        new SortShuffleWriter(other, mapId, context, shuffleExecutorComponents)
+        new SortShuffleWriter(other, mapId, context, metrics, shuffleExecutorComponents)
     }
     new S3ShuffleWriter[K, V](writer)
   }


### PR DESCRIPTION
This pull-request builds on top of https://github.com/IBM/spark-s3-shuffle/pull/92 

- This PR reduces the number of supported spark releases to Spark 3.4.4 and 3.5.5 onwards. 
- The default Java version is increased to Java 17.

This PR fixes https://github.com/IBM/spark-s3-shuffle/issues/88