### PR TITLE
Fix Github CI build and some minor linting issues.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             scala: 2.12.18
           - spark: 3.5.0
             scala: 2.13.8
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # Upgrading this version requires an additional sbt setup step.
     env:
       SPARK_VERSION: ${{ matrix.spark }}
       SCALA_VERSION: ${{ matrix.scala }}
@@ -72,14 +72,14 @@ jobs:
         echo "If either of these checks fail run: 'sbt scalafmtAll && sbt scalafmtSbt'"
         sbt scalafmtSbtCheck
         sbt scalafmtCheckAll
-    - name: Test Default Shuffle Fetch
+    - name: Run tests
+      if: startsWith(matrix.scala, '2.')
       shell: bash
-      if: startsWith(matrix.scala, '2.12.')
       run: |
         sbt test
-    - name: Test Spark Shuffle Fetch
+    - name: Run tests with Spark Shuffle Fetch enabled
       shell: bash
-      if: startsWith(matrix.scala, '2.12.') && !startsWith(matrix.spark, '3.2.')
+      if: !startsWith(matrix.spark, '3.2.')
       env:
         USE_SPARK_SHUFFLE_FETCH: "true"
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,18 +68,17 @@ jobs:
         cache: sbt
     - name: Check formatting
       shell: bash
-      run: |
+      run: |-
         echo "If either of these checks fail run: 'sbt scalafmtAll && sbt scalafmtSbt'"
         sbt scalafmtSbtCheck
         sbt scalafmtCheckAll
     - name: Run tests
-      if: startsWith(matrix.scala, '2.')
       shell: bash
       run: |
         sbt test
     - name: Run tests with Spark Shuffle Fetch enabled
       shell: bash
-      if: !startsWith(matrix.spark, '3.2.')
+      if: ${{ !startsWith(matrix.spark, '3.2.') }}
       env:
         USE_SPARK_SHUFFLE_FETCH: "true"
       run: |

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ to Java > 11:
   --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
   --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
   --add-opens=java.base/sun.nio.cs=ALL-UNNAMED
-  --add-opens=java.base/sun.security.action=ALL-UNNAMED -
-  -add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+  --add-opens=java.base/sun.security.action=ALL-UNNAMED 
+  --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
   --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache2.0
 //
 
-scalaVersion := sys.env.getOrElse("SCALA_VERSION", "2.12.15")
+scalaVersion := sys.env.getOrElse("SCALA_VERSION", "2.12.18")
 organization := "com.ibm"
 name := "spark-s3-shuffle"
-val sparkVersion = sys.env.getOrElse("SPARK_VERSION", "3.3.1")
+val sparkVersion = sys.env.getOrElse("SPARK_VERSION", "3.5.0")
 
 enablePlugins(GitVersioning, BuildInfoPlugin)
 
@@ -29,20 +29,9 @@ buildInfoKeys ++= Seq[BuildInfoKey](
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
   "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
-  "org.apache.spark" %% "spark-hadoop-cloud" % sparkVersion % "compile"
+  "org.apache.spark" %% "spark-hadoop-cloud" % sparkVersion % "compile",
+  "org.scalatest" %% "scalatest" % "3.2.19" % Test
 )
-
-libraryDependencies ++= (if (scalaBinaryVersion.value == "2.12")
-                           Seq(
-                             "junit" % "junit" % "4.13.2" % Test,
-                             "org.scalatest" %% "scalatest" % "3.2.2" % Test,
-                             "ch.cern.sparkmeasure" %% "spark-measure" % "0.18" % Test,
-                             "org.scalacheck" %% "scalacheck" % "1.15.2" % Test,
-                             "org.mockito" % "mockito-core" % "3.4.6" % Test,
-                             "org.scalatestplus" %% "mockito-3-4" % "3.2.9.0" % Test,
-                             "com.github.sbt" % "junit-interface" % "0.13.3" % Test
-                           )
-                         else Seq())
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:MaxPermSize=2048M", "-XX:+CMSClassUnloadingEnabled")

--- a/src/main/scala/org/apache/spark/shuffle/helper/S3ShuffleDispatcher.scala
+++ b/src/main/scala/org/apache/spark/shuffle/helper/S3ShuffleDispatcher.scala
@@ -211,7 +211,6 @@ class S3ShuffleDispatcher extends Logging {
   def closeCachedBlocks(shuffleIndex: Int): Unit = {
     val filter = (blockId: BlockId) =>
       blockId match {
-        case RDDBlockId(_, _)                              => false
         case ShuffleBlockId(shuffleId, _, _)               => shuffleId == shuffleIndex
         case ShuffleBlockBatchId(shuffleId, _, _, _)       => shuffleId == shuffleIndex
         case ShuffleBlockChunkId(shuffleId, _, _, _)       => shuffleId == shuffleIndex
@@ -223,14 +222,9 @@ class S3ShuffleDispatcher extends Logging {
         case ShuffleMergedDataBlockId(_, shuffleId, _, _)  => shuffleId == shuffleIndex
         case ShuffleMergedIndexBlockId(_, shuffleId, _, _) => shuffleId == shuffleIndex
         case ShuffleMergedMetaBlockId(_, shuffleId, _, _)  => shuffleId == shuffleIndex
-        case BroadcastBlockId(_, _)                        => false
-        case TaskResultBlockId(_)                          => false
-        case StreamBlockId(_, _)                           => false
-        case TempLocalBlockId(_)                           => false
-        case TempShuffleBlockId(_)                         => false
-        case TestBlockId(_)                                => false
+        case _                                             => false
       }
-    cachedFileStatus.remove(filter, _)
+    cachedFileStatus.remove(filter, None)
   }
 
   /** Open a block for writing.

--- a/src/main/scala/org/apache/spark/shuffle/sort/S3ShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/sort/S3ShuffleManager.scala
@@ -23,20 +23,15 @@
 package org.apache.spark.shuffle.sort
 
 import com.ibm.SparkS3ShuffleBuild
-import org.apache.hadoop.fs.{Path, PathFilter}
 import org.apache.spark._
-import org.apache.spark.internal.{Logging, config}
+import org.apache.spark.internal.Logging
 import org.apache.spark.shuffle._
 import org.apache.spark.shuffle.api.ShuffleExecutorComponents
 import org.apache.spark.shuffle.helper.{S3ShuffleDispatcher, S3ShuffleHelper}
 import org.apache.spark.storage.S3ShuffleReader
 
-import java.io.IOException
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, Future}
 
 /** This class was adapted from Apache Spark: SortShuffleManager.scala
   */


### PR DESCRIPTION
This PR includes a variety of fixes:
- A fix of the Github CI build system due to a regression in newer versions of Ubuntu.
- Fix conditionals in Github CI.
- Support for Scala 2.13 in the unit tests.
- A fix in the caching system, which might have prevented the system from working altogether.
  This line triggered a linting error due to `_`.

```
cachedFileStatus.remove(filter, _)
```

   This was changed to 

   ```
    cachedFileStatus.remove(filter, None)
```